### PR TITLE
Feature/jvisenti/global context

### DIFF
--- a/Example/RZEffectsDemo/RZEffectsDemo.xcodeproj/project.pbxproj
+++ b/Example/RZEffectsDemo/RZEffectsDemo.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		D41B361B1A844AA30076C724 /* RZCompositeEffect.m in Sources */ = {isa = PBXBuildFile; fileRef = D41B360E1A844AA30076C724 /* RZCompositeEffect.m */; };
 		D41B361C1A844AA30076C724 /* RZEffectView.m in Sources */ = {isa = PBXBuildFile; fileRef = D41B36111A844AA30076C724 /* RZEffectView.m */; };
 		D41B361D1A844AA30076C724 /* RZViewTexture.m in Sources */ = {isa = PBXBuildFile; fileRef = D41B36131A844AA30076C724 /* RZViewTexture.m */; };
+		D41B9E851A94FD9B003E4865 /* RZEffectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = D41B9E841A94FD9B003E4865 /* RZEffectContext.m */; };
 		D41DB81C1A681DDD00BFF5F9 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D41DB81B1A681DDD00BFF5F9 /* main.m */; };
 		D41DB81F1A681DDD00BFF5F9 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D41DB81E1A681DDD00BFF5F9 /* AppDelegate.m */; };
 		D41DB8221A681DDD00BFF5F9 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D41DB8211A681DDD00BFF5F9 /* ViewController.m */; };
@@ -60,6 +61,8 @@
 		D41B36111A844AA30076C724 /* RZEffectView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RZEffectView.m; sourceTree = "<group>"; };
 		D41B36121A844AA30076C724 /* RZViewTexture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RZViewTexture.h; sourceTree = "<group>"; };
 		D41B36131A844AA30076C724 /* RZViewTexture.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RZViewTexture.m; sourceTree = "<group>"; };
+		D41B9E831A94FD9B003E4865 /* RZEffectContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RZEffectContext.h; sourceTree = "<group>"; };
+		D41B9E841A94FD9B003E4865 /* RZEffectContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RZEffectContext.m; sourceTree = "<group>"; };
 		D41DB8161A681DDD00BFF5F9 /* RZEffectsDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RZEffectsDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D41DB81A1A681DDD00BFF5F9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D41DB81B1A681DDD00BFF5F9 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -120,6 +123,8 @@
 				D41B36051A844AA30076C724 /* RZRenderLoop.m */,
 				D41B36061A844AA30076C724 /* RZTransform3D.h */,
 				D41B36071A844AA30076C724 /* RZTransform3D.m */,
+				D41B9E831A94FD9B003E4865 /* RZEffectContext.h */,
+				D41B9E841A94FD9B003E4865 /* RZEffectContext.m */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -320,6 +325,7 @@
 				D41B36171A844AA30076C724 /* RZRenderLoop.m in Sources */,
 				D41B361C1A844AA30076C724 /* RZEffectView.m in Sources */,
 				D41DB81C1A681DDD00BFF5F9 /* main.m in Sources */,
+				D41B9E851A94FD9B003E4865 /* RZEffectContext.m in Sources */,
 				D41B36161A844AA30076C724 /* RZQuadMesh.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/RZEffectsDemo/RZEffectsDemo/ViewController.m
+++ b/Example/RZEffectsDemo/RZEffectsDemo/ViewController.m
@@ -52,7 +52,7 @@
         
         self.effectView = [[RZEffectView alloc] initWithSourceView:self.contentView effect:self.effect dynamicContent:YES];
         self.effectView.backgroundColor = [UIColor blackColor];
-        self.effectView.userInteractionEnabled = NO;
+        self.effectView.framesPerSecond = 60;
         
         self.effectView.effectTransform.rotation = GLKQuaternionMake(-0.133518726, 0.259643972, 0.0340433009, 0.955821096);
         

--- a/RZEffects/Core/RZEffectContext.h
+++ b/RZEffects/Core/RZEffectContext.h
@@ -1,0 +1,25 @@
+//
+//  RZEffectContext.h
+//
+//  Created by Rob Visentin on 2/18/15.
+//  Copyright (c) 2015 Raizlabs. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <OpenGLES/EAGLDrawable.h>
+
+@interface RZEffectContext : NSObject
+
+@property (nonatomic, readonly) BOOL isCurrentContext;
+
++ (instancetype)defaultContext;
+
+- (instancetype)initWithSharedContext:(RZEffectContext *)shareContext NS_DESIGNATED_INITIALIZER;
+
+- (BOOL)renderbufferStorage:(NSUInteger)target fromDrawable:(id<EAGLDrawable>)drawable;
+- (BOOL)presentRenderbuffer:(NSUInteger)target;
+
+- (void)runBlock:(void(^)(RZEffectContext *context))block;
+- (void)runBlock:(void(^)(RZEffectContext *context))block wait:(BOOL)wait;
+
+@end

--- a/RZEffects/Core/RZEffectContext.h
+++ b/RZEffects/Core/RZEffectContext.h
@@ -5,19 +5,40 @@
 //  Copyright (c) 2015 Raizlabs. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
 #import <OpenGLES/EAGLDrawable.h>
+#import <CoreGraphics/CGColor.h>
+#import <CoreVideo/CVPixelBuffer.h>
+#import <CoreVideo/CVOpenGLESTextureCache.h>
+
+#import "RZEffectsCommon.h"
 
 @interface RZEffectContext : NSObject
 
 @property (nonatomic, readonly) BOOL isCurrentContext;
 
+@property (assign, nonatomic) CGRect viewport;
+@property (assign, nonatomic) CGColorRef clearColor; // default nil (opaque black)
+
+@property (assign, nonatomic, getter=isDepthTestEnabled) BOOL depthTestEnabled; // default NO
+@property (assign, nonatomic, getter=isStencilTestEnabled) BOOL stencilTestEnabled; // default NO
+
+@property (assign, nonatomic) GLenum cullFace; // default GL_BACK
+
+@property (assign, nonatomic) GLenum activeTexture; // default GL_TEXTURE0
+
 + (instancetype)defaultContext;
+
++ (RZEffectContext *)currentContext;
 
 - (instancetype)initWithSharedContext:(RZEffectContext *)shareContext NS_DESIGNATED_INITIALIZER;
 
 - (BOOL)renderbufferStorage:(NSUInteger)target fromDrawable:(id<EAGLDrawable>)drawable;
 - (BOOL)presentRenderbuffer:(NSUInteger)target;
+
+- (GLuint)vertexShaderWithSource:(NSString *)vshSrc;
+- (GLuint)fragmentShaderWithSource:(NSString *)fshSrc;
+
+- (CVOpenGLESTextureRef)textureWithPixelBuffer:(CVPixelBufferRef)pixelBuffer;
 
 - (void)runBlock:(void(^)(RZEffectContext *context))block;
 - (void)runBlock:(void(^)(RZEffectContext *context))block wait:(BOOL)wait;

--- a/RZEffects/Core/RZEffectContext.m
+++ b/RZEffects/Core/RZEffectContext.m
@@ -7,17 +7,53 @@
 
 #import <OpenGLES/ES2/glext.h>
 #import <OpenGLES/EAGL.h>
+#import <objc/runtime.h>
 
 #import "RZEffectContext.h"
+
+static GLuint RZCompileShader(const GLchar *source, GLenum type)
+{
+    GLuint shader = glCreateShader(type);
+    GLint length = (GLuint)strlen(source);
+
+    glShaderSource(shader, 1, &source, &length);
+    glCompileShader(shader);
+
+#if DEBUG
+    GLint success;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
+
+    if ( success != GL_TRUE ) {
+        GLint length;
+        glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &length);
+
+        GLchar *logText = malloc(length + 1);
+        logText[length] = '\0';
+        glGetShaderInfoLog(shader, length, NULL, logText);
+
+        fprintf(stderr, "Error compiling shader: %s\n", logText);
+
+        free(logText);
+    }
+#endif
+
+    return shader;
+}
 
 @interface RZEffectContext ()
 
 @property (strong, nonatomic, readwrite) dispatch_queue_t contextQueue;
 @property (strong, nonatomic) EAGLContext *glContext;
 
+@property (strong, nonatomic) NSMutableDictionary *compiledShaders;
+
+@property (assign, nonatomic) CVOpenGLESTextureCacheRef textureCache;
+
 @end
 
 @implementation RZEffectContext
+
+#pragma mark - lifecycle
 
 + (instancetype)defaultContext
 {
@@ -29,6 +65,11 @@
     });
 
     return s_DefaultContext;
+}
+
++ (RZEffectContext *)currentContext
+{
+    return objc_getAssociatedObject([EAGLContext currentContext], _cmd);
 }
 
 - (instancetype)init
@@ -44,28 +85,159 @@
         _contextQueue = dispatch_queue_create(queueLabel, DISPATCH_QUEUE_SERIAL);
 
         _glContext = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2 sharegroup:shareContext.glContext.sharegroup];
+        objc_setAssociatedObject(_glContext, @selector(currentContext), self, OBJC_ASSOCIATION_ASSIGN);
+
+        _compiledShaders = [NSMutableDictionary dictionary];
+
+        CVOpenGLESTextureCacheCreate(NULL, NULL, _glContext, NULL, &_textureCache);
+
+        _activeTexture = GL_TEXTURE0;
+
+        self.cullFace = GL_BACK;
     }
 
     return self;
 }
+
+- (void)dealloc
+{
+    CGColorRelease(_clearColor);
+
+    if ( _textureCache != nil ) {
+        CFRelease(_textureCache);
+    }
+
+    objc_setAssociatedObject(_glContext, @selector(currentContext), nil, OBJC_ASSOCIATION_ASSIGN);
+
+    if ( [EAGLContext currentContext] == self.glContext ) {
+        [EAGLContext setCurrentContext:nil];
+    }
+}
+
+#pragma mark - getters
 
 - (BOOL)isCurrentContext
 {
     return ([EAGLContext currentContext] == self.glContext);
 }
 
+#pragma mark - setters
+
+- (void)setViewport:(CGRect)viewport
+{
+    if ( !CGRectEqualToRect(_viewport, viewport) ) {
+        [self runBlock:^(RZEffectContext *context) {
+            glViewport(viewport.origin.x, viewport.origin.y, viewport.size.width, viewport.size.height);
+        }];
+
+        _viewport = viewport;
+    }
+}
+
+- (void)setClearColor:(CGColorRef)clearColor
+{
+    if ( !CGColorEqualToColor(_clearColor, clearColor) ) {
+        [self runBlock:^(RZEffectContext *context) {
+            if ( clearColor != nil ) {
+                const CGFloat *comps = CGColorGetComponents(clearColor);
+
+                size_t numComps = CGColorGetNumberOfComponents(clearColor);
+                CGFloat r, g, b, a;
+                r = g = b = a = 0.0f;
+
+                if ( numComps == 2 ) {
+                    const CGFloat *comps = CGColorGetComponents(clearColor);
+                    r = b = g = comps[0];
+                    a = comps[1];
+                }
+                else if ( numComps == 4 ) {
+                    r = comps[0];
+                    g = comps[1];
+                    b = comps[2];
+                    a = comps[3];
+                }
+                
+                glClearColor(r, g, b, a);
+            }
+            else {
+                glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+            }
+        }];
+
+        _clearColor = clearColor;
+    }
+}
+
+- (void)setDepthTestEnabled:(BOOL)depthTestEnabled
+{
+    if ( _depthTestEnabled != depthTestEnabled ) {
+        [self runBlock:^(RZEffectContext *context) {
+            if ( depthTestEnabled ) {
+                glEnable(GL_DEPTH_TEST);
+            }
+            else {
+                glDisable(GL_DEPTH_TEST);
+            }
+        }];
+
+        _depthTestEnabled = depthTestEnabled;
+    }
+}
+
+- (void)setStencilTestEnabled:(BOOL)stencilTestEnabled
+{
+    if ( _stencilTestEnabled != stencilTestEnabled ) {
+        [self runBlock:^(RZEffectContext *context) {
+            if ( stencilTestEnabled ) {
+                glEnable(GL_STENCIL_TEST);
+            }
+            else {
+                glDisable(GL_STENCIL_TEST);
+            }
+        }];
+
+        _stencilTestEnabled = stencilTestEnabled;
+    }
+}
+
+- (void)setCullFace:(GLenum)cullFace
+{
+    if ( _cullFace != cullFace ) {
+        [self runBlock:^(RZEffectContext *context) {
+            glCullFace(cullFace);
+
+            if ( cullFace != GL_NONE ) {
+                glEnable(GL_CULL_FACE);
+            }
+            else {
+                glDisable(GL_CULL_FACE);
+            }
+        }];
+
+        _cullFace = cullFace;
+    }
+}
+
+- (void)setActiveTexture:(GLenum)activeTexture
+{
+    if ( _activeTexture != activeTexture ) {
+        [self runBlock:^(RZEffectContext *context) {
+            glActiveTexture(activeTexture);
+        }];
+
+        _activeTexture = activeTexture;
+    }
+}
+
+#pragma mark - public methods
+
 - (BOOL)renderbufferStorage:(NSUInteger)target fromDrawable:(id<EAGLDrawable>)drawable
 {
     __block BOOL success = NO;
 
-    if ( self.isCurrentContext ) {
-        success = [self.glContext renderbufferStorage:target fromDrawable:drawable];
-    }
-    else {
-        [self runBlock:^(RZEffectContext *context) {
-            success = [context.glContext renderbufferStorage:target fromDrawable:drawable];
-        }];
-    }
+    [self runBlock:^(RZEffectContext *context) {
+        success = [context.glContext renderbufferStorage:target fromDrawable:drawable];
+    }];
 
     return success;
 }
@@ -74,16 +246,60 @@
 {
     __block BOOL success = NO;
 
-    if ( self.isCurrentContext ) {
-        success = [self.glContext presentRenderbuffer:target];
+    [self runBlock:^(RZEffectContext *context) {
+        success = [context.glContext presentRenderbuffer:target];
+    }];
+
+    return success;
+}
+
+- (GLuint)vertexShaderWithSource:(NSString *)vshSrc
+{
+    __block GLuint vsh;
+
+    if ( self.compiledShaders[vshSrc] != nil ) {
+        vsh = [self.compiledShaders[vshSrc] unsignedIntValue];
     }
     else {
         [self runBlock:^(RZEffectContext *context) {
-            success = [context.glContext presentRenderbuffer:target];
+            vsh = RZCompileShader([vshSrc UTF8String], GL_VERTEX_SHADER);
+            self.compiledShaders[vshSrc] = @(vsh);
         }];
     }
 
-    return success;
+    return vsh;
+}
+
+- (GLuint)fragmentShaderWithSource:(NSString *)fshSrc
+{
+    __block GLuint fsh;
+
+    if ( self.compiledShaders[fshSrc] != nil ) {
+        fsh = [self.compiledShaders[fshSrc] unsignedIntValue];
+    }
+    else {
+        [self runBlock:^(RZEffectContext *context) {
+            fsh = RZCompileShader([fshSrc UTF8String], GL_FRAGMENT_SHADER);
+            self.compiledShaders[fshSrc] = @(fsh);
+        }];
+    }
+
+    return fsh;
+}
+
+- (CVOpenGLESTextureRef)textureWithPixelBuffer:(CVPixelBufferRef)pixelBuffer
+{
+    GLsizei width = (GLsizei)CVPixelBufferGetWidth(pixelBuffer);
+    GLsizei height = (GLsizei)CVPixelBufferGetHeight(pixelBuffer);
+
+    OSType format = CVPixelBufferGetPixelFormatType(pixelBuffer);
+
+    GLenum glFormat = (format == kCVPixelFormatType_32BGRA) ? GL_BGRA : GL_RGBA;
+
+    CVOpenGLESTextureRef tex;
+    CVOpenGLESTextureCacheCreateTextureFromImage(NULL, self.textureCache, pixelBuffer, NULL, GL_TEXTURE_2D, GL_RGBA, width, height, glFormat, GL_UNSIGNED_BYTE, 0, &tex);
+
+    return tex;
 }
 
 - (void)runBlock:(void (^)(RZEffectContext *))block

--- a/RZEffects/Core/RZEffectContext.m
+++ b/RZEffects/Core/RZEffectContext.m
@@ -1,0 +1,128 @@
+//
+//  RZEffectContext.m
+//
+//  Created by Rob Visentin on 2/18/15.
+//  Copyright (c) 2015 Raizlabs. All rights reserved.
+//
+
+#import <OpenGLES/ES2/glext.h>
+#import <OpenGLES/EAGL.h>
+
+#import "RZEffectContext.h"
+
+@interface RZEffectContext ()
+
+@property (strong, nonatomic, readwrite) dispatch_queue_t contextQueue;
+@property (strong, nonatomic) EAGLContext *glContext;
+
+@end
+
+@implementation RZEffectContext
+
++ (instancetype)defaultContext
+{
+    static id s_DefaultContext = nil;
+
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        s_DefaultContext = [[self alloc] init];
+    });
+
+    return s_DefaultContext;
+}
+
+- (instancetype)init
+{
+    return [self initWithSharedContext:nil];
+}
+
+- (instancetype)initWithSharedContext:(RZEffectContext *)shareContext
+{
+    self = [super init];
+    if ( self ) {
+        const char *queueLabel = [NSString stringWithFormat:@"com.rzeffects.context-%lu", (unsigned long)self.hash].UTF8String;
+        _contextQueue = dispatch_queue_create(queueLabel, DISPATCH_QUEUE_SERIAL);
+
+        _glContext = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2 sharegroup:shareContext.glContext.sharegroup];
+    }
+
+    return self;
+}
+
+- (BOOL)isCurrentContext
+{
+    return ([EAGLContext currentContext] == self.glContext);
+}
+
+- (BOOL)renderbufferStorage:(NSUInteger)target fromDrawable:(id<EAGLDrawable>)drawable
+{
+    __block BOOL success = NO;
+
+    if ( self.isCurrentContext ) {
+        success = [self.glContext renderbufferStorage:target fromDrawable:drawable];
+    }
+    else {
+        [self runBlock:^(RZEffectContext *context) {
+            success = [context.glContext renderbufferStorage:target fromDrawable:drawable];
+        }];
+    }
+
+    return success;
+}
+
+- (BOOL)presentRenderbuffer:(NSUInteger)target
+{
+    __block BOOL success = NO;
+
+    if ( self.isCurrentContext ) {
+        success = [self.glContext presentRenderbuffer:target];
+    }
+    else {
+        [self runBlock:^(RZEffectContext *context) {
+            success = [context.glContext presentRenderbuffer:target];
+        }];
+    }
+
+    return success;
+}
+
+- (void)runBlock:(void (^)(RZEffectContext *))block
+{
+    [self runBlock:block wait:YES];
+}
+
+- (void)runBlock:(void (^)(RZEffectContext *context))block wait:(BOOL)wait
+{
+    if ( block != nil ) {
+        if ( self.isCurrentContext ) {
+            if ( wait ) {
+                block(self);
+            }
+            else {
+                dispatch_async(self.contextQueue, ^{
+                    block(self);
+                });
+            }
+        }
+        else {
+            void (^innerBlock)() = ^{
+                if ( !self.isCurrentContext ) {
+                    [EAGLContext setCurrentContext:self.glContext];
+                }
+
+                @autoreleasepool {
+                    block(self);
+                }
+            };
+
+            if ( wait ) {
+                dispatch_sync(self.contextQueue, innerBlock);
+            }
+            else {
+                dispatch_async(self.contextQueue, innerBlock);
+            }
+        }
+    }
+}
+
+@end

--- a/RZEffects/Core/RZEffectContext.m
+++ b/RZEffects/Core/RZEffectContext.m
@@ -84,7 +84,7 @@ static GLuint RZCompileShader(const GLchar *source, GLenum type)
         const char *queueLabel = [NSString stringWithFormat:@"com.rzeffects.context-%lu", (unsigned long)self.hash].UTF8String;
         _contextQueue = dispatch_queue_create(queueLabel, DISPATCH_QUEUE_SERIAL);
 
-        _glContext = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2 sharegroup:shareContext.glContext.sharegroup];
+        _glContext = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3 sharegroup:shareContext.glContext.sharegroup];
         objc_setAssociatedObject(_glContext, @selector(currentContext), self, OBJC_ASSOCIATION_ASSIGN);
 
         _compiledShaders = [NSMutableDictionary dictionary];

--- a/RZEffects/Core/RZQuadMesh.m
+++ b/RZEffects/Core/RZQuadMesh.m
@@ -6,9 +6,9 @@
 //
 
 #import <OpenGLES/ES2/glext.h>
-#import <OpenGLES/EAGL.h>
 
 #import "RZQuadMesh.h"
+#import "RZEffectContext.h"
 
 typedef struct _RZBufferSet {
     GLuint vbo, ibo;
@@ -55,16 +55,7 @@ void RZGenerateQuadMesh(NSInteger subdivisions, GLvoid **vertices, GLuint *numVe
 
 + (instancetype)quadWithSubdivisionLevel:(NSInteger)subdivisons
 {
-    RZQuadMesh *mesh = nil;
-    
-    if ( [EAGLContext currentContext] != nil ) {
-        mesh = [[self alloc] initWithSubdivisionLevel:subdivisons];
-    }
-    else {
-        NSLog(@"Failed to initialize %@: No active EAGLContext.", NSStringFromClass(self));
-    }
-    
-    return mesh;
+    return [[self alloc] initWithSubdivisionLevel:subdivisons];
 }
 
 - (void)dealloc
@@ -88,7 +79,7 @@ void RZGenerateQuadMesh(NSInteger subdivisions, GLvoid **vertices, GLuint *numVe
 
 - (void)setupGL
 {
-    if ( [EAGLContext currentContext] != nil ) {
+    if ( [RZEffectContext currentContext] != nil ) {
         [self teardownGL];
         
         glGenVertexArraysOES(1, &_vao);
@@ -112,7 +103,7 @@ void RZGenerateQuadMesh(NSInteger subdivisions, GLvoid **vertices, GLuint *numVe
         glBindBuffer(GL_ARRAY_BUFFER, 0);
     }
     else {
-        NSLog(@"Failed to setup %@: No active EAGLContext.", NSStringFromClass([self class]));
+        NSLog(@"Failed to setup %@: No active context!", NSStringFromClass([self class]));
     }
 }
 

--- a/RZEffects/Effects/RZClothEffect.m
+++ b/RZEffects/Effects/RZClothEffect.m
@@ -134,7 +134,7 @@ void main(void)
 
 - (NSInteger)preferredLevelOfDetail
 {
-    return 6;
+    return 5;
 }
 
 - (BOOL)link

--- a/RZEffects/Effects/RZClothEffect.m
+++ b/RZEffects/Effects/RZClothEffect.m
@@ -134,7 +134,7 @@ void main(void)
 
 - (NSInteger)preferredLevelOfDetail
 {
-    return 5;
+    return 6;
 }
 
 - (BOOL)link

--- a/RZEffects/UIKit/RZEffectView.m
+++ b/RZEffects/UIKit/RZEffectView.m
@@ -8,6 +8,7 @@
 #import <OpenGLES/ES2/glext.h>
 
 #import "RZEffectView.h"
+#import "RZEffectContext.h"
 #import "RZRenderLoop.h"
 #import "RZViewTexture.h"
 #import "RZQuadMesh.h"
@@ -31,7 +32,8 @@ static const GLenum s_GLDiscards[]  = {GL_DEPTH_ATTACHMENT, GL_COLOR_ATTACHMENT0
     GLint _backingHeight;
 }
 
-@property (strong, nonatomic) EAGLContext *context;
+@property (strong, nonatomic) RZEffectContext *context;
+
 @property (strong, nonatomic) RZRenderLoop *renderLoop;
 
 @property (strong, nonatomic) IBOutlet UIView *sourceView;
@@ -81,13 +83,6 @@ static const GLenum s_GLDiscards[]  = {GL_DEPTH_ATTACHMENT, GL_COLOR_ATTACHMENT0
     [self rz_createTexture];
 }
 
-- (void)dealloc
-{
-    if( [EAGLContext currentContext] == self.context ) {
-        [EAGLContext setCurrentContext:nil];
-    }
-}
-
 - (void)willMoveToSuperview:(UIView *)newSuperview
 {
     if ( newSuperview == nil ) {
@@ -107,30 +102,28 @@ static const GLenum s_GLDiscards[]  = {GL_DEPTH_ATTACHMENT, GL_COLOR_ATTACHMENT0
 - (void)setFrame:(CGRect)frame
 {
     [super setFrame:frame];
-    
-    if ( self.context != nil ) {
-        [EAGLContext setCurrentContext:self.context];
+
+    [self.context runBlock:^(RZEffectContext *context){
         [self rz_updateBuffersWithSize:frame.size];
-    }
+    }];
 }
 
 - (void)setBounds:(CGRect)bounds
 {
     [super setBounds:bounds];
     
-    if ( self.context != nil ) {
-        [EAGLContext setCurrentContext:self.context];
+    [self.context runBlock:^(RZEffectContext *context){
         [self rz_updateBuffersWithSize:bounds.size];
-    }
+    }];
 }
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor
 {
     [super setBackgroundColor:backgroundColor];
-    
-    if ( self.context != nil ) {
+
+    [self.context runBlock:^(RZEffectContext *context){
         [self rz_setClearColorWithColor:backgroundColor];
-    }
+    } wait:NO];
 }
 
 - (void)setPaused:(BOOL)paused
@@ -155,16 +148,16 @@ static const GLenum s_GLDiscards[]  = {GL_DEPTH_ATTACHMENT, GL_COLOR_ATTACHMENT0
 
 - (void)setEffect:(RZEffect *)effect
 {
-    [EAGLContext setCurrentContext:self.context];
-    
-    [self rz_setEffect:effect];
+    [self.context runBlock:^(RZEffectContext *context){
+        [self rz_setEffect:effect];
+    }];
 }
 
 - (void)setModel:(id<RZRenderable>)model
 {
-    [EAGLContext setCurrentContext:self.context];
-    
-    [self rz_setModel:model];
+    [self.context runBlock:^(RZEffectContext *context){
+        [self rz_setModel:model];
+    }];
 }
 
 - (void)setNeedsDisplay
@@ -190,71 +183,73 @@ static const GLenum s_GLDiscards[]  = {GL_DEPTH_ATTACHMENT, GL_COLOR_ATTACHMENT0
     self.backgroundColor = [UIColor clearColor];
     self.opaque = NO;
     self.userInteractionEnabled = NO;
-    
-    self.context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
-    
+
     self.effectCamera = [RZCamera cameraWithFieldOfView:GLKMathDegreesToRadians(30.0f) aspectRatio:1.0f nearClipping:0.001f farClipping:10.0f];
     
     self.effectTransform = [RZTransform3D transform];
-    
-    if ( [EAGLContext setCurrentContext:self.context] ) {
+
+    self.context = [RZEffectContext defaultContext];
+
+    [self.context runBlock:^(RZEffectContext *context){
         [self rz_updateBuffersWithSize:self.bounds.size];
         [self rz_setEffect:self.effect];
-        
+
         self.renderLoop = [RZRenderLoop renderLoop];
         [self.renderLoop setUpdateTarget:self action:@selector(rz_update:)];
         [self.renderLoop setRenderTarget:self action:@selector(rz_render)];
 
         self.framesPerSecond = kRZEffectViewDefaultFPS;
-        
+
         [self rz_setClearColorWithColor:self.backgroundColor];
-        
+
         glEnable(GL_DEPTH_TEST);
         glEnable(GL_CULL_FACE);
-    }
+    }];
 }
 
 - (void)rz_createBuffers
 {
-    glGenFramebuffers(2, _fbos);
-    glGenRenderbuffers(1, &_crb);
-    
-    glBindFramebuffer(GL_FRAMEBUFFER, _fbos[0]);
-    glBindRenderbuffer(GL_RENDERBUFFER, _crb);
-    
-    [self.context renderbufferStorage:GL_RENDERBUFFER fromDrawable:(CAEAGLLayer *)self.layer];
-    
-    glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_WIDTH, &_backingWidth);
-    glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_HEIGHT, &_backingHeight);
-    
-    glGenRenderbuffers(2, _drbs);
-    glBindRenderbuffer(GL_RENDERBUFFER, _drbs[0]);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24_OES, _backingWidth, _backingHeight);
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _drbs[0]);
-    
-    glBindFramebuffer(GL_FRAMEBUFFER, _fbos[1]);
-    glBindRenderbuffer(GL_RENDERBUFFER, _drbs[1]);
-    
-    glGenTextures(2 * RZ_EFFECT_AUX_TEXTURES, _auxTex[0]);
-    
-    for ( int tex = 0; tex < 2; tex++ ) {
-        for ( int i = 0; i < RZ_EFFECT_AUX_TEXTURES; i++ ) {
-            GLsizei denom = pow(2.0, i);
-            
-            glBindTexture(GL_TEXTURE_2D, _auxTex[tex][i]);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, _backingWidth / denom, _backingHeight / denom, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+    [self.context runBlock:^(RZEffectContext *context) {
+        glGenFramebuffers(2, _fbos);
+        glGenRenderbuffers(1, &_crb);
+
+        glBindFramebuffer(GL_FRAMEBUFFER, _fbos[0]);
+        glBindRenderbuffer(GL_RENDERBUFFER, _crb);
+
+        [context renderbufferStorage:GL_RENDERBUFFER fromDrawable:(CAEAGLLayer *)self.layer];
+
+        glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_WIDTH, &_backingWidth);
+        glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_HEIGHT, &_backingHeight);
+
+        glGenRenderbuffers(2, _drbs);
+        glBindRenderbuffer(GL_RENDERBUFFER, _drbs[0]);
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24_OES, _backingWidth, _backingHeight);
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _drbs[0]);
+
+        glBindFramebuffer(GL_FRAMEBUFFER, _fbos[1]);
+        glBindRenderbuffer(GL_RENDERBUFFER, _drbs[1]);
+
+        glGenTextures(2 * RZ_EFFECT_AUX_TEXTURES, _auxTex[0]);
+
+        for ( int tex = 0; tex < 2; tex++ ) {
+            for ( int i = 0; i < RZ_EFFECT_AUX_TEXTURES; i++ ) {
+                GLsizei denom = pow(2.0, i);
+
+                glBindTexture(GL_TEXTURE_2D, _auxTex[tex][i]);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, _backingWidth / denom, _backingHeight / denom, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+            }
         }
-    }
-    
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24_OES, _backingWidth, _backingHeight);
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _drbs[1]);
-    
-    glBindTexture(GL_TEXTURE_2D, 0);
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24_OES, _backingWidth, _backingHeight);
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _drbs[1]);
+        
+        glBindTexture(GL_TEXTURE_2D, 0);
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        glBindRenderbuffer(GL_RENDERBUFFER, 0);
+    }];
 }
 
 - (void)rz_updateBuffersWithSize:(CGSize)size
@@ -295,8 +290,9 @@ static const GLenum s_GLDiscards[]  = {GL_DEPTH_ATTACHMENT, GL_COLOR_ATTACHMENT0
 - (void)rz_createTexture
 {
     if ( self.sourceView != nil ) {
-        [EAGLContext setCurrentContext:self.context];
-        [self rz_setViewTexture:[RZViewTexture textureWithSize:self.sourceView.bounds.size]];
+        [self.context runBlock:^(RZEffectContext *context){
+            [self rz_setViewTexture:[RZViewTexture textureWithSize:self.sourceView.bounds.size]];
+        }];
     }
 }
 
@@ -334,15 +330,14 @@ static const GLenum s_GLDiscards[]  = {GL_DEPTH_ATTACHMENT, GL_COLOR_ATTACHMENT0
 }
 
 - (void)rz_setClearColorWithColor:(UIColor *)color
-{
-    [EAGLContext setCurrentContext:self.context];
-    
+{    
     if ( color != nil ) {
         CGColorRef cgColor = color.CGColor;
         const CGFloat *comps = CGColorGetComponents(cgColor);
         
         size_t numComps = CGColorGetNumberOfComponents(cgColor);
         CGFloat r, g, b, a;
+        r = g = b = a = 0.0f;
         
         if ( numComps == 2 ) {
             const CGFloat *comps = CGColorGetComponents(cgColor);
@@ -398,59 +393,59 @@ static const GLenum s_GLDiscards[]  = {GL_DEPTH_ATTACHMENT, GL_COLOR_ATTACHMENT0
 
 - (void)rz_render
 {
-    [EAGLContext setCurrentContext:self.context];
-    
-    [self.viewTexture bindGL];
-    
-    [self rz_congfigureEffect];
+    [self.context runBlock:^(RZEffectContext *context){
+        [self.viewTexture bindGL];
 
-    int fbo = 0;
-    
-    GLuint downsample = self.effect.downsampleLevel;
-    GLint denom = pow(2.0, downsample);
-    
-    while ( [self.effect prepareToDraw] ) {
-        glViewport(0, 0, _backingWidth/denom, _backingHeight/denom);
+        [self rz_congfigureEffect];
+
+        int fbo = 0;
+
+        GLuint downsample = self.effect.downsampleLevel;
+        GLint denom = pow(2.0, downsample);
+
+        while ( [self.effect prepareToDraw] ) {
+            glViewport(0, 0, _backingWidth/denom, _backingHeight/denom);
+            glBindFramebuffer(GL_FRAMEBUFFER, _fbos[fbo]);
+
+            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, _auxTex[fbo][downsample], 0);
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+            [self display];
+
+            glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, s_GLDiscards);
+            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
+            glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, &s_GLDiscards[1]);
+
+            glBindTexture(GL_TEXTURE_2D, _auxTex[fbo][downsample]);
+            fbo = 1 - fbo;
+
+            downsample = self.effect.downsampleLevel;
+            denom = pow(2.0, downsample);
+        };
+
+        // TODO: what if the last effect has lower downsample?
+
+        glViewport(0, 0, _backingWidth, _backingHeight);
+
         glBindFramebuffer(GL_FRAMEBUFFER, _fbos[fbo]);
-        
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, _auxTex[fbo][downsample], 0);
+
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, _crb);
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-        
+
         [self display];
-        
+
         glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, s_GLDiscards);
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
+
+        glBindRenderbuffer(GL_RENDERBUFFER, _crb);
+        [context presentRenderbuffer:GL_RENDERBUFFER];
+
         glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, &s_GLDiscards[1]);
         
-        glBindTexture(GL_TEXTURE_2D, _auxTex[fbo][downsample]);
-        fbo = 1 - fbo;
-        
-        downsample = self.effect.downsampleLevel;
-        denom = pow(2.0, downsample);
-    };
-    
-    // TODO: what if the last effect has lower downsample?
-    
-    glViewport(0, 0, _backingWidth, _backingHeight);
-
-    glBindFramebuffer(GL_FRAMEBUFFER, _fbos[fbo]);
-    
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, _crb);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    
-    [self display];
-    
-    glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, s_GLDiscards);
-    
-    glBindRenderbuffer(GL_RENDERBUFFER, _crb);
-    [self.context presentRenderbuffer:GL_RENDERBUFFER];
-
-    glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, &s_GLDiscards[1]);
-    
-    glUseProgram(0);
-    glBindTexture(GL_TEXTURE_2D, 0);
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    glBindRenderbuffer(GL_RENDERBUFFER, 0);
+        glUseProgram(0);
+        glBindTexture(GL_TEXTURE_2D, 0);
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        glBindRenderbuffer(GL_RENDERBUFFER, 0);
+    }];
 }
 
 @end


### PR DESCRIPTION
Added an RZEffectContext to keep track of OpenGL state and cache shaders and textures. Only one context should be needer per app, but there is the option to create multiple contexts. Each context is created with its own dispatch queue so that it doesn't stomp on the main thread's EAGLContext. All work should be performed using the `runBlock` method. You can specify whether to wait for the block to finish running or not. The default is `wait = YES`, but you may want `wait = NO` for performing heavy loading tasks on a background context.
